### PR TITLE
diactric marks cause error:

### DIFF
--- a/export-history.py
+++ b/export-history.py
@@ -210,7 +210,7 @@ for channel_id,channel_data in room_state.items():
             
             if num_messages > 0:
                 with open(output_dir + t_oldest.strftime('%Y-%m-%d') + '-' + channel_data['name'] + '.json','w') as f:
-                    f.write(history_data_text)
+                     f.write(history_data_text.encode('utf-8').strip())
                 sleep(polite_pause)
             elif num_messages > count_max:
                 logger.error('Too many messages for this room today. SKIPPING.')


### PR DESCRIPTION
Traceback (most recent call last):
File "export-history.py", line 214, in <module>
f.write(history_data_text)
UnicodeEncodeError: 'ascii' codec
can't encode character